### PR TITLE
Rw shore

### DIFF
--- a/libraft-agent/src/main/java/io/libraft/agent/RaftAgent.java
+++ b/libraft-agent/src/main/java/io/libraft/agent/RaftAgent.java
@@ -234,6 +234,7 @@ public class RaftAgent implements Raft {
                 timer,
                 mapper,
                 getSelfAsMember(raftClusterConfiguration.getSelf(), cluster),
+                configuration.getAllAddresses(),
                 cluster,
                 configuration.getConnectTimeout(),
                 configuration.getMinReconnectInterval(),

--- a/libraft-agent/src/main/java/io/libraft/agent/RaftAgentConstants.java
+++ b/libraft-agent/src/main/java/io/libraft/agent/RaftAgentConstants.java
@@ -63,4 +63,10 @@ public abstract class RaftAgentConstants {
      * a successful connection to a Raft server.
      */
     public static final int CONNECT_TIMEOUT = 5000;
+    
+    /**
+     * Indicates whether the local server's listener should listen
+     * on all addresses or only on the specified address
+     */
+    public static final boolean ALL_ADDRESSES = false;
 }

--- a/libraft-agent/src/main/java/io/libraft/agent/configuration/RaftConfiguration.java
+++ b/libraft-agent/src/main/java/io/libraft/agent/configuration/RaftConfiguration.java
@@ -73,6 +73,7 @@ public final class RaftConfiguration {
     private static final String SNAPSHOTS = "snapshots";
     private static final String DATABASE = "database";
     private static final String CLUSTER = "cluster";
+    private static final String ALL_ADDRESSES = "allAddresses";
 
     @Min(1)
     @Max(RaftConfigurationConstants.SIXTY_SECONDS)
@@ -115,6 +116,10 @@ public final class RaftConfiguration {
     @NotNull
     @JsonProperty(ADDITIONAL_RECONNECT_INTERVAL_RANGE)
     private int additionalReconnectIntervalRange = RaftAgentConstants.ADDITIONAL_RECONNECT_INTERVAL_RANGE;
+    
+    @NotNull
+    @JsonProperty(ALL_ADDRESSES)
+    private boolean allAddresses = RaftAgentConstants.ALL_ADDRESSES;
 
     @JsonIgnore
     private final TimeUnit timeUnit = RaftConfigurationConstants.DEFAULT_TIME_UNIT;
@@ -330,6 +335,16 @@ public final class RaftConfiguration {
     public int getAdditionalReconnectIntervalRange() {
         return additionalReconnectIntervalRange;
     }
+    
+    /**
+     * Get a flag indicating whether the local server should listen on all addresses 
+     * or on the specified one only
+     * 
+     * @return the all-addresses flag
+     */
+    public boolean getAllAddresses() {
+    	return allAddresses;
+    }
 
     /**
      * Set the maximum additional amount of time added to
@@ -342,6 +357,16 @@ public final class RaftConfiguration {
      */
     public void setAdditionalReconnectIntervalRange(int additionalReconnectIntervalRange) {
         this.additionalReconnectIntervalRange = additionalReconnectIntervalRange;
+    }
+    
+    /**
+     * Set the flag indicating whether the local server listens on all addresses
+     * or not
+     * 
+     * @param aa the all-addresses value
+     */
+    public void setAllAddresses(boolean aa) {
+    	this.allAddresses = aa;
     }
 
     /**
@@ -406,7 +431,8 @@ public final class RaftConfiguration {
                 && additionalReconnectIntervalRange == other.additionalReconnectIntervalRange
                 && raftDatabaseConfiguration.equals(other.raftDatabaseConfiguration)
                 && raftSnapshotsConfiguration.equals(other.raftSnapshotsConfiguration)
-                && raftClusterConfiguration.equals(other.raftClusterConfiguration);
+                && raftClusterConfiguration.equals(other.raftClusterConfiguration)
+                && allAddresses == other.allAddresses;
     }
 
     @Override
@@ -422,7 +448,8 @@ public final class RaftConfiguration {
                 additionalReconnectIntervalRange,
                 raftDatabaseConfiguration,
                 raftSnapshotsConfiguration,
-                raftClusterConfiguration
+                raftClusterConfiguration,
+                allAddresses
         );
     }
 
@@ -441,6 +468,7 @@ public final class RaftConfiguration {
                 .add(DATABASE, raftDatabaseConfiguration)
                 .add(SNAPSHOTS, raftSnapshotsConfiguration)
                 .add(CLUSTER, raftClusterConfiguration)
+                .add(ALL_ADDRESSES, allAddresses)
                 .toString();
     }
 }

--- a/libraft-agent/src/main/java/io/libraft/agent/persistence/JDBCBase.java
+++ b/libraft-agent/src/main/java/io/libraft/agent/persistence/JDBCBase.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -123,7 +124,7 @@ abstract class JDBCBase {
             checkNotNull(statement);
             try {
                 try {
-                    addDatabaseCreateStatementsToBatch(statement);
+                    addDatabaseCreateStatementsToBatch(statement, connection.getMetaData());
                     statement.executeBatch();
                 } finally {
                     closeSilently(statement);
@@ -159,7 +160,7 @@ abstract class JDBCBase {
         return initialized;
     }
 
-    protected abstract void addDatabaseCreateStatementsToBatch(Statement statement) throws Exception;
+    protected abstract void addDatabaseCreateStatementsToBatch(Statement batchStatement, DatabaseMetaData metadata) throws Exception;
 
     private void setupConnection() throws SQLException {
         if (connection == null) {

--- a/libraft-agent/src/main/java/io/libraft/agent/persistence/JDBCBase.java
+++ b/libraft-agent/src/main/java/io/libraft/agent/persistence/JDBCBase.java
@@ -126,6 +126,7 @@ abstract class JDBCBase {
                 try {
                     addDatabaseCreateStatementsToBatch(statement, connection.getMetaData());
                     statement.executeBatch();
+                    initializeDatabase(connection);
                 } finally {
                     closeSilently(statement);
                 }
@@ -161,6 +162,7 @@ abstract class JDBCBase {
     }
 
     protected abstract void addDatabaseCreateStatementsToBatch(Statement batchStatement, DatabaseMetaData metadata) throws Exception;
+    protected abstract void initializeDatabase(Connection connection) throws Exception;
 
     private void setupConnection() throws SQLException {
         if (connection == null) {

--- a/libraft-agent/src/main/java/io/libraft/agent/persistence/JDBCLog.java
+++ b/libraft-agent/src/main/java/io/libraft/agent/persistence/JDBCLog.java
@@ -55,7 +55,7 @@ import static com.google.common.base.Preconditions.checkState;
 /**
  * Implementation of {@code Log} that uses a JDBC backend.
  * <p/>
- * This implementation creates and uses a single table called {@code log_index} with the following structure:
+ * This implementation creates and uses a single table called {@code entries} with the following structure:
  * <pre>
  * +-----------+-----------+----------+----------+
  * | log_index |   term    |   type   |   data   |
@@ -139,6 +139,11 @@ public final class JDBCLog extends JDBCBase implements Log {
         		batchStatement.addBatch("CREATE INDEX entries_index ON entries(log_index DESC)");
         	}
         }
+    }
+    
+    @Override
+    protected void initializeDatabase(Connection connection) throws Exception {
+    	// no special initialization required
     }
 
     @Override

--- a/libraft-agent/src/main/java/io/libraft/agent/snapshots/SnapshotsDAO.java
+++ b/libraft-agent/src/main/java/io/libraft/agent/snapshots/SnapshotsDAO.java
@@ -30,6 +30,7 @@ package io.libraft.agent.snapshots;
 
 import org.skife.jdbi.v2.ResultIterator;
 import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException;
 import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.BindBean;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
@@ -68,8 +69,12 @@ abstract class SnapshotsDAO {
      */
     @Transaction
     void createSnapshotsTableWithIndex() {
-        createSnapshotsTable();
-        createTimestampIndexForSnapshotsTable();
+    	try {
+          createSnapshotsTable();
+          createTimestampIndexForSnapshotsTable();
+    	} catch(UnableToExecuteStatementException e) {
+    		// nada
+    	}
     }
 
     /**
@@ -77,13 +82,13 @@ abstract class SnapshotsDAO {
      */
     // FIXME (AG): I'm essentially using the timestamp as a primary key
     // I did this is because auto-increment indices have different syntaxes in different dbs - might be best to create an explicit index
-    @SqlUpdate("create table if not exists snapshots(filename varchar(255) not null, ts bigint unique, last_term bigint not null, last_index bigint not null)")
+    @SqlUpdate("create table snapshots(filename varchar(255) not null, ts bigint unique, last_term bigint not null, last_index bigint not null)")
     abstract void createSnapshotsTable();
 
     /**
      * Create the index for the {@code snapshots} table.
      */
-    @SqlUpdate("create index if not exists ts_index on snapshots(ts)")
+    @SqlUpdate("create index ts_index on snapshots(ts)")
     abstract void createTimestampIndexForSnapshotsTable();
 
     /**


### PR DESCRIPTION
The two commits on the RWShore branch solve the following problems:
1. table-create statements used highly non-standard SQL. TINYINT turns out to be non-standard (changed to SMALLINT). More importantly, the IF NOT EXISTS clause isn't standard and broke (in particular) the embedded Derby database I wanted to use. Fixing the log and store was simple: use the database metadata to see if the table exists. The snapshot DAO object is a hack: simply ignore exceptions thrown from the create code. There may be a better way to fix the DAO object, but I didn't have the time to figure out how the JDBI package works.
2. For reasons that I don't understand, different hosts on my network resolve hostnames differently; some pick up the IPv4 address and some the IPv6 address. This prevents all the nodes from communicating, since some nodes were listening on the v6 address but other nodes were attempting to contact them using the v4 address. My fix is to add an all-address boolean flag to the RAFT configuration; if the flag is true, then the fully-resolved bind address used for the server employs the port number only (making the IP address a wildcard and effectively binding the server to both the v4 and v6 addresses).
